### PR TITLE
Fix the bug that a container may not have ps command

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -24,7 +24,7 @@ readonly myname
 export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/"
 
 # Check for required program(s)
-req_programs 'awk docker grep stat tee tail wc xargs truncate sed'
+req_programs 'awk docker grep stat tee tail wc xargs truncate sed pgrep'
 
 # Ensure we can connect to docker daemon
 if ! docker ps -q >/dev/null 2>&1; then

--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -254,7 +254,7 @@ check_5_6() {
   printcheck=0
   for c in $containers; do
 
-    processes=$(docker exec "$c" ps -el 2>/dev/null | grep -c sshd | awk '{print $1}')
+    processes=$(docker inspect "$c" --format '{{ .State.Pid }}' 2>/dev/null | xargs pgrep -a -P 2>/dev/null | grep -c sshd | awk '{print $1}')
     if [ "$processes" -ge 1 ]; then
       # If it's the first container, fail the test
       if [ $fail -eq 0 ]; then


### PR DESCRIPTION
The reason why we should not execute ps command in containers:
* some containers don't have ps command.
* if a container shares the PID namespace with the host machine, the check command would report false positives.

The better way is to get the PID of the first process inside containers in the host PID namespace first, then find all processes whose PPID is the PID of the first process inside the container.