### PR TITLE
Fix missing check ID in 2.18 INFO output

### DIFF
--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -415,7 +415,7 @@ check_2_18() {
   fi
   local desc="$desc (Deprecated)"
   local check="$id - $desc"
-  info -c "$desc"
+  info -c "$check"
   logcheckresult "INFO"
 }
 


### PR DESCRIPTION
## Summary
- Check 2.18 was calling `info -c "$desc"`, so the INFO line omitted the check ID.
- Switch it to `info -c "$check"` so the output matches neighboring daemon checks (for example 2.17).

Fixes #567

## Test plan
- [ ] Run the daemon configuration section and confirm 2.18 INFO output includes `2.18 -` in the message.